### PR TITLE
修复斗鱼cdn地址

### DIFF
--- a/douyu.py
+++ b/douyu.py
@@ -148,7 +148,7 @@ class DouYu:
         else:
             key, url = self.get_js()
             ret['2000p'] = url
-        ret['flv'] = "http://hdltc1.douyucdn.cn/live/{}.flv?uuid=".format(key)
+        ret['flv'] = "http://huos1a.douyucdn2.cn/live/{}.flv?uuid=".format(key)
         return ret
 
 


### PR DESCRIPTION
网络移动/联通，原地址无法使用。
更换新地址之后可以播放。