### PR TITLE
flv修改为pc_js方式获取

### DIFF
--- a/douyu.py
+++ b/douyu.py
@@ -148,7 +148,7 @@ class DouYu:
         else:
             key, url = self.get_js()
             ret['2000p'] = url
-        ret['flv'] = "http://hdltc1.douyucdn.cn/live/{}.flv?uuid=".format(key)
+        ret['flv'] = self.get_pc_js()
         return ret
 
 


### PR DESCRIPTION
- 抓包发现原flv链接失效，修改为pc_js方式获取。
- 获取到的json可知pc_js现在就是flv链接，播放正常。