### PR TITLE
添加 Docker 支持

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,23 @@
+name: build-image
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWD }}
+
+      - name: Build the docker image and push
+        run: |
+          docker buildx create --use
+          docker buildx build --platform linux/amd64,linux/arm64 --tag ${{ secrets.DOCKERHUB_USERNAME }}/real-url-proxy-server:latest --file Dockerfile --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM --platform=$BUILDPLATFORM node:alpine as base
+
+RUN apk add --no-cache python3 python3-dev py3-pip
+RUN pip3 install requests PyExecJS
+
+FROM base as build
+
+ENV PORT 8888
+ENV REFRESH 7200
+
+COPY . /real-url-proxy-server
+WORKDIR /real-url-proxy-server
+
+ENTRYPOINT python3 real-url-proxy-server.py --port $PORT --refresh $REFRESH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=$BUILDPLATFORM node:alpine as base
 
 RUN apk add --no-cache python3 python3-dev py3-pip
-RUN pip3 install requests PyExecJS
+RUN pip3 install requests PyExecJS --break-system-packages
 
 FROM base as build
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,20 @@ LOG_FILE: 日志文件路径，为空则仅输出至控制台。</br>
 ```bash
 # 从本地构建镜像
 docker build --tag real-url-proxy-server .
-docker run -p 8888:8888 -e PORT=8888 -e REFRESH=7200 real-url-proxy-server
+docker run -d --name real-url-proxy-server --restart unless-stopped \
+    -p 8888:8888 \
+    -e PORT=8888 \
+    -e REFRESH=7200 \
+    real-url-proxy-server
 
 # 使用 Docker Hub 镜像
-docker run -p 8888:8888 -e PORT=8888 -e REFRESH=7200 futuretech6/real-url-proxy-server  # 目前支持amd64, amr64
+docker run -d --name real-url-proxy-server --restart unless-stopped \
+    -p 8888:8888 \
+    -e PORT=8888 \
+    -e REFRESH=7200 \
+    futuretech6/real-url-proxy-server  # 目前支持 amd64, amr64
+# 也可也使用 docker-compose
+docker compose up -d
 ```
 
 ## 感谢

--- a/README.md
+++ b/README.md
@@ -28,5 +28,15 @@ LOG_FILE: 日志文件路径，为空则仅输出至控制台。</br>
 ## 其它
 获取到的实际地址会以301跳转或EXTM3U形式返回，播放端得到播放地址后，后续正常播放过程中不会再次访问代理服务器，因此服务器负载和流量均很低。本人在家中将其部署于刷了Padavan的小米路由器上，并通过OTT盒子进行观看。（斗鱼，bilibili是301跳转，虎牙会一直访问代理服务器返回#EXTM3U）
 
+## Docker 运行
+```bash
+# 从本地构建镜像
+docker build --tag real-url-proxy-server .
+docker run -p 8888:8888 -e PORT=8888 -e REFRESH=7200 real-url-proxy-server
+
+# 使用 Docker Hub 镜像
+docker run -p 8888:8888 -e PORT=8888 -e REFRESH=7200 futuretech6/real-url-proxy-server  # 目前支持amd64, amr64
+```
+
 ## 感谢
 获取直播源地址使用的douyu.py、huya.py及bilibili.py代码来自于<a href="https://github.com/wbt5/real-url" target="_blank">Real-Url</a>项目，在此表示由衷的感谢！

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  real-url-proxy-server:
+    build:
+      context: .
+    image: futuretech6/real-url-proxy-server
+    container_name: real-url-proxy-server
+    restart: unless-stopped
+    ports:
+      - 8888:8888
+    environment:
+      - PORT=8888
+      - REFRESH=7200


### PR DESCRIPTION
服务器上没有node环境，于是添加了docker支持，设置了 rain-dl/real-url-proxy-server 仓库下的 DOCKERHUB_USERNAME 和 DOCKERHUB_PASSWD 这两个 secrets 后每次仓库有变动会自动构建 `rain-dl/real-url-proxy-server` 这个镜像